### PR TITLE
Configure OpenTelemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## Pre-Requisites
 
 * Java 21+
-* Container runtime (e.g. Podman or Docker) for running the PostgreSQL Dev Service
+* Container runtime (e.g. Podman or Docker) for running the OpenTelemetry and PostgreSQL Dev Services
 * The application expects you to have the following API key as an environment variable:
 - `OPENAI_API_KEY`: OpenAI API key
 
@@ -26,6 +26,21 @@ Run `Application.java` in your IDE or use the following command:
 ```bash
 mvn spring-boot:run
 ```
+
+Under the hood, the Arconia framework will automatically spin up a PostgreSQL database server and a Grafana LGTM observability platform using Testcontainers.
+
+## Observability
+
+The application logs will show you the URL where you can access the Grafana observability platform and information about logs, metrics, and traces being exported to the platform.
+
+```logs
+...o.t.grafana.LgtmStackContainer           : Access to the Grafana dashboard: http://localhost:38125
+```
+
+By default, logs, metrics, and traces are exported via OTLP using the HTTP/Protobuf format.
+
+In Grafana, you can query the traces from the "Explore" page, selecting the "Tempo" data source.
+You can also explore metrics in "Explore > Metrics" and logs in "Explore > Logs".
 
 ## Using local models
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
@@ -72,7 +76,17 @@
             <artifactId>viritin</artifactId>
             <version>2.8.22</version>
         </dependency>
+        <dependency>
+            <groupId>io.arconia</groupId>
+            <artifactId>arconia-opentelemetry-spring-boot-starter</artifactId>
+        </dependency>
 
+        <dependency>
+            <groupId>io.arconia</groupId>
+            <artifactId>arconia-dev-services-opentelemetry-lgtm</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
         <dependency>
             <groupId>io.arconia</groupId>
             <artifactId>arconia-dev-services-postgresql</artifactId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,3 +29,4 @@ spring.jpa.hibernate.ddl-auto=create
 #spring.jpa.show-sql=true
 
 arconia.dev.services.postgresql.image-name=pgvector/pgvector:pg17
+arconia.otel.metrics.interval=5s


### PR DESCRIPTION
Out-of-the-box OpenTelemetry configuration for logs, metrics, and traces + Dev Service to start up automatically a Grafana LGTM container.

It can be easily disabled with `arconia.otel.enabled=false` if it's not desired.